### PR TITLE
Fix import in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```js
 <script>
-import { LoginWindow } from 'levelup:svelte-accounts-ui'
+import { LoginWindow } from 'meteor/levelup:svelte-accounts-ui'
 </script>
 
 <LoginWindow />
@@ -18,7 +18,7 @@ import { LoginWindow } from 'levelup:svelte-accounts-ui'
 
 ```js
 <script>
-import { Login, Signup, Logout } from 'levelup:svelte-accounts-ui'
+import { Login, Signup, Logout } from 'meteor/levelup:svelte-accounts-ui'
 </script>
 
 <Signup heading="Create User" />


### PR DESCRIPTION
I just installed this on a fresh meteor project and the import in the readme didn't work.

Your video [here](https://www.youtube.com/watch?v=BBoj3iLDNmE&list=PLLnpHn493BHHrJWLpGqCvLFwsWQ9jCBQR&index=6) imports from `meteor/` and that worked for me. 

I fixed the README here.